### PR TITLE
#4: Added all markdown plugins supported by pulldown-cmark

### DIFF
--- a/src/post.rs
+++ b/src/post.rs
@@ -1,6 +1,6 @@
 use crate::url::{Url, UrlBuf};
 use anyhow::{anyhow, Result};
-use pulldown_cmark::{html, Parser};
+use pulldown_cmark::{html, Options, Parser};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use serde_yaml;
@@ -143,7 +143,16 @@ impl Post<Unicase> {
         let (yaml_start, yaml_stop, body_start) = frontmatter_indices(input)?;
         let mut post: Post<Unicase> = serde_yaml::from_str(&input[yaml_start..yaml_stop])?;
         post.id = id.to_owned();
-        html::push_html(&mut post.body, Parser::new(&input[body_start..]));
+        let mut options = Options::empty();
+        options.insert(Options::ENABLE_FOOTNOTES);
+        options.insert(Options::ENABLE_SMART_PUNCTUATION);
+        options.insert(Options::ENABLE_STRIKETHROUGH);
+        options.insert(Options::ENABLE_TABLES);
+        options.insert(Options::ENABLE_TASKLISTS);
+        html::push_html(
+            &mut post.body,
+            Parser::new_ext(&input[body_start..], options),
+        );
         Ok(post)
     }
 }

--- a/test-data/blog-copy/theme/static/style.css
+++ b/test-data/blog-copy/theme/static/style.css
@@ -208,7 +208,7 @@ code {
     border: 1px solid #ddd;
     border-radius: 4px;
     color: #444;
-    font-family: 'Inconsolata', ;
+    font-family: 'Inconsolata';
     font-size: 70%;
 }
 
@@ -222,13 +222,12 @@ pre {
     line-height: 1.5em;
     font-size: 16px;
     tab-size: 4;
-    font-size: 70%;
 }
 
 pre code {
     border: none;
     padding: 0px;
-    font-size: 70%;
+    font-size: 100%;
 }
 
 table {


### PR DESCRIPTION
Addresses #4.

Plugins: footnotes, smart punctuation, strikethrough, tables.

Also updated style to fix font size problems with `<pre>` and `<code>` elements.